### PR TITLE
Allow multiple types and graphs to be handled

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -4,20 +4,25 @@ Data used within a [semantic.works](http://semantic.works)-stack (and [mu-cl-res
 
 ## Configuration
 
-### Environment variables
+### config.json
 
-The service can be configured through the following environment variables:
-* `GRAPH`: graph to write to.
-* `RDF_TYPE`: rdf type of the objects to watch for missing `mu:uuid`.
+The service can be configured through a configuration file `config.json`. If you use the docker-compose config below, this file should be in `config/uuid-generation/`. This file consists of one object with the accepted types as keys and a list of all the graphs those types should be checked in. For example:
+
+``` json
+{
+    "http://data.vlaanderen.be/ns/besluit#Agendapunt": ["http://mu.semte.ch/graphs/public"],
+    "http://data.vlaanderen.be/ns/besluit#Zitting": ["http://mu.semte.ch/graphs/public"],
+    "http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#Email": ["http://mu.semte.ch/graphs/public", "http://mu.semte.ch/graphs/emails"]
+}
+```
 
 ### docker-compose snippet
 
 ```yaml
 uuid-generation:
   build: https://github.com/kanselarij-vlaanderen/uuid-generation-service.git
-  environment:
-    RDF_TYPE: "http://data.europa.eu/eli/ontology#LegalResource"
-    GRAPH: "http://mu.semte.ch/graphs/staatsblad"
+  volumes:
+    - ./config/uuid-generation/:/config
 ```
 
 ### delta-notifier configuration
@@ -50,8 +55,8 @@ uuid-generation:
 
 ### POST /delta
 
-Internal endpoint which receives [delta's](https://github.com/mu-semtech/delta-notifier).
+Internal endpoint which receives [deltas](https://github.com/mu-semtech/delta-notifier).
 
 ### POST /run
 
-Service-endpoint to manually trigger running uuid-insertion for the configured type.
+Service-endpoint to manually trigger running uuid-insertion for the configured types.

--- a/app.js
+++ b/app.js
@@ -1,36 +1,60 @@
+import fs from 'fs';
 import bodyParser from 'body-parser';
+import json from 'express';
 import { app, errorHandler } from 'mu';
 import { filterDeltaForInsertedType } from './lib/delta';
 import selectSubjectsWithoutUuid from './queries/select-without-uuid';
 import insertUuid from './queries/insert-uuid';
 
-const RDF_TYPE = process.env.RDF_TYPE;
-const GRAPH = process.env.GRAPH;
 
-app.post('/run', async (req, res) => {
-  const subjectsWithout = await selectSubjectsWithoutUuid(RDF_TYPE, [GRAPH]);
-  if (subjectsWithout.length > 0) {
-    console.log(`Found ${subjectsWithout.length} objects of type <${RDF_TYPE}> without a uuid. Handling now.`);
-    for (const subject of subjectsWithout) {
-      await insertUuid(subject, [GRAPH]);
+app.use(json());
+
+const CONFIG = readConfig();
+
+function readConfig() {
+  const configText = fs.readFileSync('/config/config.json', { encoding: 'utf8' });
+  const config = JSON.parse(configText);
+
+  return config;
+}
+
+app.post('/run', async (_req, res) => {
+  let uris = new Set();
+
+  for (let [type, graphs] of Object.entries(CONFIG)) {
+    const subjectsWithout = await selectSubjectsWithoutUuid(type, graphs);
+    if (subjectsWithout.length > 0) {
+      console.log(`Found ${subjectsWithout.length} objects of type <${type}> without a uuid. Handling now.`);
+      for (const subject of subjectsWithout) {
+        await insertUuid(subject, graphs);
+        uris.add(subject);
+      }
     }
   }
-  const data = subjectsWithout.map(s => {
-    return { uri: s };
-  });
 
-  return res.send({
-    data
-  });
+  let ret = [];
+
+  uris.forEach((uri) => {
+    ret.push({
+      "uri": uri,
+    })
+  })
+
+  return res.status(200).send(JSON.stringify(
+    ret
+  ));
 });
 
 app.post('/delta', bodyParser.json(), async (req, res) => {
-  res.status(202).end();
-  const insertedSubjects = filterDeltaForInsertedType(req.body, RDF_TYPE);
-  if (insertedSubjects.length > 0) {
-    console.log(`Received ${insertedSubjects.length} object inserts of type <${RDF_TYPE}> through delta's. Handling now.`);
-    for (const subject of insertedSubjects) {
-      await insertUuid(subject, [GRAPH]);
+  res.status(202).send();
+  for (let [type, graphs] of Object.entries(CONFIG)) {
+    console.log(JSON.stringify(req.body))
+    const insertedSubjects = filterDeltaForInsertedType(req.body, type);
+    if (insertedSubjects.length > 0) {
+      console.log(`Received ${insertedSubjects.length} object inserts of type ${type} through deltas. Handling now.`);
+      for (const subject of insertedSubjects) {
+        await insertUuid(subject, graphs);
+      }
     }
   }
 });

--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import bodyParser from 'body-parser';
-import json from 'express';
 import { app, errorHandler } from 'mu';
 import { filterDeltaForInsertedType } from './lib/delta';
 import selectSubjectsWithoutUuid from './queries/select-without-uuid';
@@ -41,7 +40,9 @@ app.post('/run', async (_req, res) => {
   })
 
   return res.status(200).send(JSON.stringify(
-    ret
+    {
+      "data": ret
+    }
   ));
 });
 

--- a/app.js
+++ b/app.js
@@ -5,9 +5,6 @@ import { filterDeltaForInsertedType } from './lib/delta';
 import selectSubjectsWithoutUuid from './queries/select-without-uuid';
 import insertUuid from './queries/insert-uuid';
 
-
-app.use(json());
-
 const CONFIG = readConfig();
 
 function readConfig() {

--- a/app.js
+++ b/app.js
@@ -48,7 +48,6 @@ app.post('/run', async (_req, res) => {
 app.post('/delta', bodyParser.json(), async (req, res) => {
   res.status(202).send();
   for (let [type, graphs] of Object.entries(CONFIG)) {
-    console.log(JSON.stringify(req.body))
     const insertedSubjects = filterDeltaForInsertedType(req.body, type);
     if (insertedSubjects.length > 0) {
       console.log(`Received ${insertedSubjects.length} object inserts of type ${type} through deltas. Handling now.`);


### PR DESCRIPTION
As mentioned in the chat, this PR allows uuid-generation-service to handle multple different types, each with their own set of graphs. Configuration is done through a `config.json`, as documented in the README.